### PR TITLE
Remove Rounded Corners on Tag Badge

### DIFF
--- a/assets/_sass/_main.scss
+++ b/assets/_sass/_main.scss
@@ -3,7 +3,6 @@ main {
   section { overflow: hidden; }
 
   img {
-    @extend .img-circle;
     @extend .img-responsive;
 
     &.pull-left {  margin-right: 40px;  }


### PR DESCRIPTION
I'm assuming the corner rounding on the shield badge was unintentional. Regardless, it is ugly and must go.